### PR TITLE
Change www.apache.org/dist to downloads.apache.org

### DIFF
--- a/_layouts/downloads.html
+++ b/_layouts/downloads.html
@@ -88,7 +88,7 @@ layout: default
 
                 <a class="indexable" id="keys"></a>
                 <h4>Keys</h4>
-                <p>You can access the <a href="https://www.apache.org/dist/openwhisk/KEYS">Release Keys</a> to verify the release artifacts.</p>
+                <p>You can access the <a href="https://downloads.apache.org/openwhisk/KEYS">Release Keys</a> to verify the release artifacts.</p>
 
                 <a class="indexable" id="unified-releases"></a>
                 <h4>Unified Releases</h4>
@@ -115,9 +115,9 @@ layout: default
                           <version>0.9.0-incubating</version>
                           <a href="https://www.apache.org/dyn/closer.cgi/openwhisk/incubating/openwhisk-0.9.0-incubating-sources.tar.gz">
                             Source code</a>
-                          <a href="https://www.apache.org/dist/openwhisk/incubating/openwhisk-0.9.0-incubating-sources.tar.gz.sha512">SHA-512 checksum</a>
+                          <a href="https://downloads.apache.org/openwhisk/incubating/openwhisk-0.9.0-incubating-sources.tar.gz.sha512">SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/incubating/openwhisk-0.9.0-incubating-sources.tar.gz.asc">PGP signature</a>
+                            href="https://downloads.apache.org/openwhisk/incubating/openwhisk-0.9.0-incubating-sources.tar.gz.asc">PGP signature</a>
                         </div>
                       </div>
 
@@ -128,10 +128,10 @@ layout: default
                           <a
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/openwhisk-apigateway-0.11.0-sources.tar.gz">Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-apigateway-0.11.0-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-apigateway-0.11.0-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-apigateway-0.11.0-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-apigateway-0.11.0-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -152,10 +152,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/openwhisk-runtime-docker-1.14.0-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-docker-1.14.0-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-docker-1.14.0-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-docker-1.14.0-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-docker-1.14.0-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -168,10 +168,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/openwhisk-runtime-dotnet-1.14.0-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-dotnet-1.14.0-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-dotnet-1.14.0-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-dotnet-1.14.0-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-dotnet-1.14.0-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -184,10 +184,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/openwhisk-runtime-go-1.15.0-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-go-1.15.0-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-go-1.15.0-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-go-1.15.0-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-go-1.15.0-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -200,10 +200,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/openwhisk-runtime-java-1.14.0-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-java-1.14.0-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-java-1.14.0-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-java-1.14.0-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-java-1.14.0-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -216,10 +216,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/openwhisk-runtime-nodejs-1.15.0-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-nodejs-1.15.0-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-nodejs-1.15.0-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-nodejs-1.15.0-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-nodejs-1.15.0-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -232,10 +232,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/openwhisk-runtime-php-1.14.0-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-php-1.14.0-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-php-1.14.0-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-php-1.14.0-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-php-1.14.0-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -248,10 +248,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/openwhisk-runtime-python-1.14.0-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-python-1.14.0-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-python-1.14.0-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-python-1.14.0-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-python-1.14.0-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -264,10 +264,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/openwhisk-runtime-ruby-1.14.0-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-ruby-1.14.0-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-ruby-1.14.0-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-ruby-1.14.0-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-ruby-1.14.0-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -280,10 +280,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/openwhisk-runtime-rust-1.0.0-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-rust-1.0.0-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-rust-1.0.0-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-rust-1.0.0-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-rust-1.0.0-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -296,10 +296,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/openwhisk-runtime-swift-1.14.0-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-swift-1.14.0-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-swift-1.14.0-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-runtime-swift-1.14.0-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-runtime-swift-1.14.0-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -319,10 +319,10 @@ layout: default
                           <a
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/openwhisk-cli-1.0.0-sources.tar.gz">Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-cli-1.0.0-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-cli-1.0.0-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-cli-1.0.0-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-cli-1.0.0-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -335,10 +335,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/openwhisk-wskdeploy-1.0.0-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-wskdeploy-1.0.0-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-wskdeploy-1.0.0-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-wskdeploy-1.0.0-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-wskdeploy-1.0.0-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -358,10 +358,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/openwhisk-catalog-0.11.0-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-catalog-0.11.0-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-catalog-0.11.0-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-catalog-0.11.0-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-catalog-0.11.0-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -374,10 +374,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/openwhisk-composer-0.12.0-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-composer-0.12.0-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-composer-0.12.0-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-composer-0.12.0-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-composer-0.12.0-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -398,10 +398,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/openwhisk-client-go-1.0.0-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-client-go-1.0.0-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-client-go-1.0.0-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-client-go-1.0.0-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-client-go-1.0.0-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -414,10 +414,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/openwhisk-client-js-3.21.1-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-client-js-3.21.1-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-client-js-3.21.1-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/openwhisk-client-js-3.21.1-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/openwhisk-client-js-3.21.1-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -437,10 +437,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/incubating/openwhisk-package-alarms-2.0.0-incubating-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/incubating/openwhisk-package-alarms-2.0.0-incubating-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/incubating/openwhisk-package-alarms-2.0.0-incubating-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/incubating/openwhisk-package-alarms-2.0.0-incubating-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/incubating/openwhisk-package-alarms-2.0.0-incubating-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -453,10 +453,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/incubating/openwhisk-package-cloudant-2.0.0-incubating-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/incubating/openwhisk-package-cloudant-2.0.0-incubating-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/incubating/openwhisk-package-cloudant-2.0.0-incubating-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/incubating/openwhisk-package-cloudant-2.0.0-incubating-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/incubating/openwhisk-package-cloudant-2.0.0-incubating-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>
@@ -469,10 +469,10 @@ layout: default
                             href="https://www.apache.org/dyn/closer.cgi/openwhisk/incubating/openwhisk-package-kafka-2.0.0-incubating-sources.tar.gz">
                             Source code</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/incubating/openwhisk-package-kafka-2.0.0-incubating-sources.tar.gz.sha512">
+                            href="https://downloads.apache.org/openwhisk/incubating/openwhisk-package-kafka-2.0.0-incubating-sources.tar.gz.sha512">
                             SHA-512 checksum</a>
                           <a
-                            href="https://www.apache.org/dist/openwhisk/incubating/openwhisk-package-kafka-2.0.0-incubating-sources.tar.gz.asc">
+                            href="https://downloads.apache.org/openwhisk/incubating/openwhisk-package-kafka-2.0.0-incubating-sources.tar.gz.asc">
                             PGP signature</a>
                         </div>
                       </div>


### PR DESCRIPTION
Change our downloads page as requested by ASF Infra to use new
downloads.apache.org domain for signature/key/checksum verifications.