### PR TITLE
Update README with recommended versions for website build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ Apache OpenWhisk is a cloud-first distributed event-based programming service. I
 
 ### Install Prerequisites
 
-- Download and install Node.js: see [https://nodejs.org/](https://nodejs.org/)
-- Download and install Ruby: see [https://www.ruby-lang.org/en/documentation/installation/](https://www.ruby-lang.org/en/documentation/installation/)
+- Download and install Node.js (recommend v10 LTS): see [https://nodejs.org/](https://nodejs.org/
+- Download and install NPM (recommend v6.14 latest): see [https://www.npmjs.com/package/npm](https://www.npmjs.com/package/npm)
+- Download and install Ruby (recommend v2.7 stable): see [https://www.ruby-lang.org/en/documentation/installation/](https://www.ruby-lang.org/en/documentation/installation/)
 
 ```sh
 # Verify Node and Node Package Manager are installed

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Apache OpenWhisk is a cloud-first distributed event-based programming service. I
 
 ### Install Prerequisites
 
-- Download and install Node.js (recommend v10 LTS): see [https://nodejs.org/](https://nodejs.org/
+- Download and install Node.js (recommend v10 LTS): see [https://nodejs.org/](https://nodejs.org/)
 - Download and install NPM (recommend v6.14 latest): see [https://www.npmjs.com/package/npm](https://www.npmjs.com/package/npm)
 - Download and install Ruby (recommend v2.7 stable): see [https://www.ruby-lang.org/en/documentation/installation/](https://www.ruby-lang.org/en/documentation/installation/)
 


### PR DESCRIPTION
Several ruby libraries updated their dependent versions of base ruby recently and caused incompatibilities when trying to run/build the jekyll website.  I thought it necessary to provide better guidance for new contribs. on what versions we recommend to have a working setup if they come to us with older versions of Ruby (for example) installed (else they would see the errors I encountered and unraveling them was not fun).