### PR TITLE
Fix Slack invite link.

### DIFF
--- a/_layouts/slack.html
+++ b/_layouts/slack.html
@@ -53,10 +53,10 @@ layout: default
     var btn = $("button");
     var res = $("#result");
     var email = $('#inputEmail');
-    var actionUrl = "https://service.us.apiconnect.ibmcloud.com/gws/apigateway/api/3e172721d7ba44ac0cb5633eae516fb1284fd9a45633e4172dbe7a780b6572c6/api/slackinvite";
+    var actionUrl = "https://js-http.nimbella.io/github.com/apache/openwhisk-website/blob/slack/apis/slack-invite.js?__c=N0_25b48535e252995f2f0960d9002bf55f_0_45725642996e63884cf84425ac19b3db85d5cfe6037cbb39dba06a2dfbff22e551827e951cc36405f048fb2d41f36edfbab2fa9d852f629f7603017ed5a7ba70d5817eada2ba18535fb355e2b627fe5f89f2b1705491eb3418d153581644b4be_";
     function handler() {
       var email = $("input")[0].value;
-      $.get(actionUrl, { email: email })
+      $.get(actionUrl, { email: email, org: 'openwhisk-team' })
         .done(function (data) {
           btn.addClass("btn-success");
           btn.html("WOOT. CHECK YOUR EMAIL!");

--- a/apis/README.md
+++ b/apis/README.md
@@ -1,0 +1,37 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+# Slack Inviter API
+
+The file [`slack-invite.js`](./slack-invite.js) implements an OpenWhisk action
+which uses the [Slack invite API](https://api.slack.com/methods/admin.users.invite)
+to send an email invitation to join the OpenWhisk Slack team.
+
+The action requires a [Slack token](https://api.slack.com/authentication/token-types#user)
+to work correctly.
+
+The API call is made in [`_layouts/slack.html`](../_layouts/slack.html) using
+[Nimbella's anonymous action invocation](https://nimbella.com). The token for
+the API call is uniquely encrypted for this action. Should this token change,
+the encrypted value can be regenerated with the following Nimbella encryption API,
+replacing the placeholder `<token>` with the actual Slack App token.
+
+```bash
+curl https://encrypt.nimbella.io/github.com/apache/openwhisk-website/blob/slack/apis/slack-invite.js?slacktoken=<token>
+```

--- a/apis/slack-invite.js
+++ b/apis/slack-invite.js
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// jshint esversion: 9
+// jshint asi:true
+const request = require('needle')
+const options = {
+  headers: {
+    'Content-Type': 'application/x-www-form-urlencoded'
+  }
+}
+
+function main({email, org, slacktoken}) {
+  return request(
+    'post',
+    `https://${org}.slack.com/api/users.admin.invite`,
+    {
+      email: email,
+      token: slacktoken,
+      set_active: true
+    },
+    options
+  )
+  .then(res => {
+    if (res.statusCode == 200 && res.body.ok) {
+      return {
+        body: { message:`Success! Check ${email} for an invite from Slack.` }
+      }
+    } else {
+      return {
+        statusCode: 400,
+        body: { error: res.body }
+      }
+    }
+  })
+  .catch(err => {
+    console.error(err)
+     return ({
+       statusCode: 400,
+       body: { error: err.message }
+    })
+  })
+}
+
+exports.main = main


### PR DESCRIPTION
Closes #477.

Add Slack inviter action using Nimbella's anonymous invocation.

The file `slack-invite.js` implements an OpenWhisk action which uses the [Slack invite API](https://api.slack.com/methods/admin.users.invite) to send an email invitation to join the OpenWhisk Slack team. The action requires a [Slack token](https://api.slack.com/authentication/token-types#user) to work correctly.

The API call is made in `_layouts/slack.html` using [Nimbella's anonymous action invocation](https://nimbella.com). The token for the API call is uniquely encrypted for this action. Should this token change, the encrypted value can be regenerated with the following Nimbella encryption API, replacing the placeholder `<token>` with the actual Slack App token.

```bash
curl https://encrypt.nimbella.io/github.com/apache/openwhisk-website/blob/slack/apis/slack-invite.js?slacktoken=<token>
```
