### PR TITLE
feat: add contributor over time graph to website

### DIFF
--- a/_layouts/community.html
+++ b/_layouts/community.html
@@ -319,6 +319,16 @@ layout: default
         </div>
       </div>
     </main>
+  
+    <main class="doc">
+      <div class="content">
+        <a class="indexable" id="contributors"></a>
+        <h3>Contributors over time</h3>
+        <a href="https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=apache/openwhisk"><img
+            src="https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=apache/openwhisk"
+            alt="Contributor over time" /></a>
+      </div>
+    </main>
 
   </section>
 

--- a/_layouts/community.html
+++ b/_layouts/community.html
@@ -190,6 +190,9 @@ layout: default
       <!-- Project Wiki -->
       <li><a href="#wiki">Project Wiki</a></li>
 
+      <!-- Contributions -->
+      <li><a href="#contributions">Contributions</a></li>
+
       <!-- Events -->
       <li><a href="#events">Events</a></li>
 
@@ -299,6 +302,20 @@ layout: default
 
     <main class="doc">
       <div class="content">
+        <a class="indexable" id="contributions"></a>
+        <h3>Contributions</h3>
+        <p>
+          The following graphic shows project contributions over time across all active OpenWhisk repositories.
+        </p>
+        <a href="https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=apache/openwhisk&merge=true"><img
+            src="https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=apache/openwhisk&merge=true"
+            alt="Contributor over time"
+            style="max-width: 600px"/></a>
+      </div>
+    </main>
+
+    <main class="doc">
+      <div class="content">
         <a class="indexable" id="events"></a>
         <h3>Events</h3>
         <h5 style="margin-top:20px;">Apache OpenWhisk events</h5>
@@ -317,16 +334,6 @@ layout: default
         <div style="">
           <a href="https://apache.org/events/current-event"><img src="https://www.apache.org/events/current-event-234x60.png" alt="Join us at the latest Apache sponsored event."/></a>
         </div>
-      </div>
-    </main>
-  
-    <main class="doc">
-      <div class="content">
-        <a class="indexable" id="contributors"></a>
-        <h3>Contributors over time across openwhisk repos</h3>
-        <a href="https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=apache/openwhisk&merge=true"><img
-            src="https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=apache/openwhisk&merge=true"
-            alt="Contributor over time" /></a>
       </div>
     </main>
 

--- a/_layouts/community.html
+++ b/_layouts/community.html
@@ -323,9 +323,9 @@ layout: default
     <main class="doc">
       <div class="content">
         <a class="indexable" id="contributors"></a>
-        <h3>Contributors over time</h3>
-        <a href="https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=apache/openwhisk"><img
-            src="https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=apache/openwhisk"
+        <h3>Contributors over time across openwhisk repos</h3>
+        <a href="https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=apache/openwhisk&merge=true"><img
+            src="https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=apache/openwhisk&merge=true"
             alt="Contributor over time" /></a>
       </div>
     </main>


### PR DESCRIPTION
Hi community!

We're the maintainers of [Apache APISIX](https://github.com/apache/apisix). To better present how our community grows, we develop a tool to show contributors growing history on https://github.com/api7/contributor-graph. Since we found it helpful, we think maybe if it could help some other community.

**WHAT IT IS**

Basically, it just shows the contributors growth over time. We would update the graph each day, so the link would always present the real-time data. There is some other stuff to [play around](https://www.apiseven.com/en/contributor-graph) if you would like to give it a try~

![image](https://user-images.githubusercontent.com/34589752/119032595-5cdbf600-b97a-11eb-992b-513f34c5782c.png)

**HOW IT WORKS**

We use Github API to get all commits, try to find the “Github way” to filter commits so the result data would be similar to Github, and then get the first commit time of each user.


Don't hesitate to tell us if there is a better place to present this graph other than this, or there are some other worries or other features you would like to have~🍻 
